### PR TITLE
Use lodash.bindall instead of lodash

### DIFF
--- a/bitstamp.js
+++ b/bitstamp.js
@@ -1,8 +1,8 @@
 var Pusher = require('pusher-node-client').PusherClient;
-var _ = require('lodash');
+var bindAll = require('lodash.bindall');
 
 var Bitstamp = function() {
-  _.bindAll(this);
+  bindAll(this);
 
   this.channel = null;
   this.client = new Pusher({

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "pusher-node-client": "0.0.8",
-    "lodash": "2.4.1"
+    "lodash.bindall": "2.4.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
No point in `require()`ing all of lodash if only one function is gonna be used. Better to just use the individual npm modules that lodash has now.
